### PR TITLE
sonatype/nexus-blobstore-s3#4 Fixed the test to also work on windows

### DIFF
--- a/src/test/java/org/sonatype/nexus/blobstore/s3/internal/S3PropertiesFileTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/s3/internal/S3PropertiesFileTest.groovy
@@ -57,7 +57,7 @@ public class S3PropertiesFileTest
     then:
       1 * s3.putObject('mybucket', 'mykey', _, _) >> { bucket, key, bytes, metadata ->
         def text = bytes.text
-        assert text.contains('testProperty=newValue\n')
+        assert text.contains('testProperty=newValue' + System.lineSeparator())
         assert metadata.contentLength == text.length()
       }
   }


### PR DESCRIPTION
Replaced the `\n` by the system-dependent line separator `System.lineSeparator()`
