### PR TITLE
Link updates to help.sonatype.com

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@
 much shaming throughout the land. If you use an editor besides Eclipse or IntelliJ, adapt the codestyle and submit a PR
 there :)
 * Fill out a CLA for us, so we can sort out all the legal parts of contributing. You can get all the information for
-this [here](https://books.sonatype.com/nexus-book/reference/contrib.html). You may go, this is for your book, is it
+this [here](https://help.sonatype.com/display/NXRM3/Bundle+Development#BundleDevelopment-ContributingBundles). You may go, this is for your book, is it
 applicable for this repo? Yes, absolutely. Follow the CLA process and email in your form. We are working on a way to
 make this simpler, as well.
 * Make sure to fill out an issue for your PR, so that we have traceability as to what you are trying to fix,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requirements
 * [Java 8+](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 * Network access to https://repository.sonatype.org/content/groups/sonatype-public-grid
 
-Also, there is a good amount of information available at [Bundle Development](https://books.sonatype.com/nexus-book/reference3/bundle-development.html#bundle-development-overview)
+Also, there is a good amount of information available at [Bundle Development Overview](https://help.sonatype.com/display/NXRM3/Bundle+Development#BundleDevelopment-BundleDevelopmentOverview)
 
 Building
 --------


### PR DESCRIPTION
Since switching over to help.sonatype.com, the book links are basically BWOKEN! OH NOES! Fixed that.

This pull request makes the following changes:
* Small link updates in README and CONTRIBUTING files
