### PR TITLE
NEXUS-13924: implement soft deletes

### DIFF
--- a/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
@@ -21,6 +21,7 @@ import org.sonatype.goodies.i18n.I18N;
 import org.sonatype.goodies.i18n.MessageBundle;
 import org.sonatype.nexus.blobstore.BlobStoreDescriptor;
 import org.sonatype.nexus.formfields.FormField;
+import org.sonatype.nexus.formfields.NumberTextFormField;
 import org.sonatype.nexus.formfields.PasswordFormField;
 import org.sonatype.nexus.formfields.StringTextFormField;
 
@@ -82,6 +83,12 @@ public class S3BlobStoreDescriptor
 
     @DefaultMessage("AWS Endpoint URL")
     String endpointHelp();
+
+    @DefaultMessage("Expiration Days")
+    String expirationLabel();
+
+    @DefaultMessage("How many days until deleted blobs are finally removed from the S3 bucket")
+    String expirationHelp();
   }
 
   private static final Messages messages = I18N.create(Messages.class);
@@ -93,6 +100,7 @@ public class S3BlobStoreDescriptor
   private final FormField assumeRole;
   private final FormField region;
   private final FormField endpoint;
+  private final FormField expiration;
 
   public S3BlobStoreDescriptor() {
     this.bucket = new StringTextFormField(
@@ -137,6 +145,13 @@ public class S3BlobStoreDescriptor
         messages.endpointHelp(),
         FormField.OPTIONAL
     );
+    this.expiration = new NumberTextFormField(
+        S3BlobStore.EXPIRATION_KEY,
+        messages.expirationLabel(),
+        messages.expirationHelp(),
+        FormField.OPTIONAL)
+        .withInitialValue(S3BlobStore.DEFAULT_EXPIRATION_IN_DAYS)
+        .withMinimumValue(1);
   }
 
   @Override
@@ -146,6 +161,6 @@ public class S3BlobStoreDescriptor
 
   @Override
   public List<FormField> getFormFields() {
-      return Arrays.asList(bucket, accessKeyId, secretAccessKey, sessionToken, assumeRole, region, endpoint);
+      return Arrays.asList(bucket, accessKeyId, secretAccessKey, sessionToken, assumeRole, region, endpoint, expiration);
   }
 }

--- a/src/test/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreTest.groovy
@@ -12,23 +12,22 @@
  */
 package org.sonatype.nexus.blobstore.s3.internal
 
-import java.io.ByteArrayInputStream
-
 import org.sonatype.nexus.blobstore.LocationStrategy
 import org.sonatype.nexus.blobstore.api.BlobId
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
 
-import com.google.inject.util.Providers
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration
 import com.amazonaws.services.s3.model.S3Object
 import com.amazonaws.services.s3.model.S3ObjectInputStream
+import com.amazonaws.services.s3.model.lifecycle.LifecycleFilter
+import com.amazonaws.services.s3.model.lifecycle.LifecycleTagPredicate
 import spock.lang.Specification
 
 /**
  * {@link S3BlobStore} tests.
  */
-public class S3BlobStoreTest
+class S3BlobStoreTest
     extends Specification
 {
 
@@ -62,6 +61,7 @@ public class S3BlobStoreTest
       """.stripMargin())
       def contentS3Object = mockS3Object('hello world')
       1 * s3.doesBucketExist('mybucket') >> true
+      1 * s3.getBucketLifecycleConfiguration('mybucket') >> blobStore.makeLifecycleConfiguration(7)
       1 * s3.doesObjectExist('mybucket', 'metadata.properties') >> false
       1 * s3.doesObjectExist('mybucket', 'content/test.properties') >> true
       1 * s3.getObject('mybucket', 'content/test.properties') >> attributesS3Object

--- a/src/test/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreTest.groovy
@@ -17,11 +17,8 @@ import org.sonatype.nexus.blobstore.api.BlobId
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.BucketLifecycleConfiguration
 import com.amazonaws.services.s3.model.S3Object
 import com.amazonaws.services.s3.model.S3ObjectInputStream
-import com.amazonaws.services.s3.model.lifecycle.LifecycleFilter
-import com.amazonaws.services.s3.model.lifecycle.LifecycleTagPredicate
 import spock.lang.Specification
 
 /**
@@ -61,7 +58,7 @@ class S3BlobStoreTest
       """.stripMargin())
       def contentS3Object = mockS3Object('hello world')
       1 * s3.doesBucketExist('mybucket') >> true
-      1 * s3.getBucketLifecycleConfiguration('mybucket') >> blobStore.makeLifecycleConfiguration(7)
+      1 * s3.getBucketLifecycleConfiguration('mybucket') >> blobStore.makeLifecycleConfiguration(S3BlobStore.DEFAULT_EXPIRATION_IN_DAYS)
       1 * s3.doesObjectExist('mybucket', 'metadata.properties') >> false
       1 * s3.doesObjectExist('mybucket', 'content/test.properties') >> true
       1 * s3.getObject('mybucket', 'content/test.properties') >> attributesS3Object


### PR DESCRIPTION
Adds a lifecycle configuration to the S3 bucket that expires content with the tag 'deleted=true' after 3 days. This results in Amazon automatically performing the 'compact blobstore' for us, without having to run the task.

~~To be determined: whether to make the `expirationInDays` parameter a form field in the UI, or to tuck it into nexus.properties.~~

Edit: consensus was to use a form field in the UI, this allows blobstore specific configuration, in case admins want to have different values for different blobstores in the same NXRM instance.