### PR TITLE
Handle bucket not empty errors gracefully.

### DIFF
--- a/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
@@ -42,6 +42,7 @@ import org.sonatype.nexus.blobstore.api.BlobStoreUsageChecker;
 import org.sonatype.nexus.common.stateguard.Guarded;
 import org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport;
 
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
 import com.amazonaws.services.s3.model.ObjectTagging;
 import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
@@ -537,6 +538,14 @@ public class S3BlobStore
       }
       else {
         log.warn("Unable to delete non-empty blob store content directory in bucket {}", getConfiguredBucket());
+      }
+    }
+    catch (AmazonS3Exception s3Exception) {
+      if ("BucketNotEmpty".equals(s3Exception.getErrorCode())) {
+        log.warn("Unable to delete non-empty blob store bucket {}", getConfiguredBucket());
+      }
+      else {
+        throw s3Exception;
       }
     }
     catch (IOException e) {


### PR DESCRIPTION
Handles a BucketNotEmpty error on remove more gracefully.  When the blobstore gets removed, a BucketNotEmpty error is just logged at WARN severity.  The bucket content directory is still checked before removing the metadata and metrics files.

Fixes #19.