### PR TITLE
Adds sample S3 bucket AWS policy to README.md (iss #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,50 @@ Log in as admin and create a new blobstore, selecting S3 as the type.
 If any fields are left blank, AWS credentials in `~/.aws/credentials`
 will be used.
 
+
+S3 Bucket Policy
+----------------
+The AWS user for accessing the S3 Blobstore bucket needs to be granted 
+permission for these actions:
+
+* s3:PutObject
+* s3:GetObject
+* s3:DeleteObject
+* s3:ListBucket
+* s3:GetLifecycleConfiguration
+* s3:PutLifecycleConfiguration
+
+Sample minimal policy where `<user-arn>` is the ARN of the AWS user and `<s3-bucket-name>` the S3 bucket name:
+
+```
+{
+    "Version": "2012-10-17",
+    "Id": "NexusS3BlobStorePolicy",
+    "Statement": [
+        {
+            "Sid": "NexusS3BlobStoreAccess",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "<user-arn>"
+            },
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:GetLifecycleConfiguration",
+                "s3:PutLifecycleConfiguration"
+            ],
+            "Resource": [
+                "arn:aws:s3:::<s3-bucket-name>",
+                "arn:aws:s3:::<s3-bucket-name>/*"
+            ]
+        }
+    ]
+}
+```
+
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
Adds a section to README.md listing the S3 bucket actions that need to be granted to the AWS user for the S3 Blobstore. Also includes a sample minimal S3 bucket policy. Fixes #31 
