### PR TITLE
Add path prefix configuration for bucket objects

### DIFF
--- a/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
@@ -48,6 +48,12 @@ public class S3BlobStoreDescriptor
     @DefaultMessage("S3 Bucket Name")
     String bucketHelp();
 
+    @DefaultMessage("Prefix")
+    String prefixLabel();
+
+    @DefaultMessage("S3 Path prefix")
+    String prefixHelp();
+
     @DefaultMessage("Access Key ID")
     String accessKeyIdLabel();
 
@@ -94,6 +100,7 @@ public class S3BlobStoreDescriptor
   private static final Messages messages = I18N.create(Messages.class);
 
   private final FormField bucket;
+  private final FormField prefix;
   private final FormField accessKeyId;
   private final FormField secretAccessKey;
   private final FormField sessionToken;
@@ -108,6 +115,12 @@ public class S3BlobStoreDescriptor
         messages.bucketLabel(),
         messages.bucketHelp(),
         FormField.MANDATORY
+    );
+    this.prefix = new StringTextFormField(
+        S3BlobStore.BUCKET_PREFIX,
+        messages.prefixLabel(),
+        messages.prefixHelp(),
+        FormField.OPTIONAL
     );
     this.accessKeyId = new StringTextFormField(
         S3BlobStore.ACCESS_KEY_ID_KEY,
@@ -161,6 +174,6 @@ public class S3BlobStoreDescriptor
 
   @Override
   public List<FormField> getFormFields() {
-      return Arrays.asList(bucket, accessKeyId, secretAccessKey, sessionToken, assumeRole, region, endpoint, expiration);
+      return Arrays.asList(bucket, prefix, accessKeyId, secretAccessKey, sessionToken, assumeRole, region, endpoint, expiration);
   }
 }

--- a/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreMetricsStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreMetricsStore.java
@@ -67,6 +67,8 @@ public class S3BlobStoreMetricsStore
 
   private String bucket;
 
+  private String bucketPrefix;
+
   private S3PropertiesFile propertiesFile;
 
   private AmazonS3 s3;
@@ -83,7 +85,7 @@ public class S3BlobStoreMetricsStore
     totalSize = new AtomicLong();
     dirty = new AtomicBoolean();
 
-    propertiesFile = new S3PropertiesFile(s3, bucket, nodeAccess.getId() + METRICS_SUFFIX + METRICS_EXTENSION);
+    propertiesFile = new S3PropertiesFile(s3, bucket, bucketPrefix + nodeAccess.getId() + METRICS_SUFFIX + METRICS_EXTENSION);
     if (propertiesFile.exists()) {
       log.info("Loading blob store metrics file {}", propertiesFile);
       propertiesFile.load();
@@ -136,6 +138,13 @@ public class S3BlobStoreMetricsStore
     this.s3 = s3;
   }
 
+
+  public void setBucketPrefix(String bucketPrefix) {
+    checkState(this.bucketPrefix == null, "Do not initialize twice");
+    checkNotNull(bucketPrefix);
+    this.bucketPrefix = bucketPrefix;
+  }
+
   @Guarded(by = STARTED)
   public BlobStoreMetrics getMetrics() {
     Stream<S3PropertiesFile> blobStoreMetricsFiles = backingFiles();
@@ -186,7 +195,7 @@ public class S3BlobStoreMetricsStore
     if (s3 == null) {
       return Stream.empty();
     } else {
-      Stream<S3PropertiesFile> stream = s3.listObjects(bucket, nodeAccess.getId()).getObjectSummaries().stream()
+      Stream<S3PropertiesFile> stream = s3.listObjects(bucket, bucketPrefix + nodeAccess.getId()).getObjectSummaries().stream()
           .filter(summary -> summary.getKey().endsWith(METRICS_EXTENSION))
           .map(summary -> new S3PropertiesFile(s3, bucket, summary.getKey()));
       return stream;


### PR DESCRIPTION
This change enables users to configure a path prefix for objects stored in the S3 bucket, effectively allowing multiple blob stores / repositories to share the same bucket. This can simplify bucket management significantly in cases where DevOps requires more control over buckets.

